### PR TITLE
Reformatted frontend structure, added slots page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,12 @@
       "name": "fepsino",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@tailwindcss/vite": "^4.0.9",
         "lucide-react": "^0.477.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -810,6 +812,14 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1398,6 +1408,11 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1663,6 +1678,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2724,6 +2747,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.3.0.tgz",
+      "integrity": "sha512-466f2W7HIWaNXTKM5nHTqNxLrHTyXybm7R0eBlVSt0k/u55tTCDO194OIx/NrYD4TS5SXKTNekXfT37kMKUjgw==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.3.0.tgz",
+      "integrity": "sha512-z7Q5FTiHGgQfEurX/FBinkOXhWREJIAB2RiU24lvcBa82PxUpwqvs/PAXb9lJyPjTs2jrl6UkLvCZVGJPeNuuQ==",
+      "dependencies": {
+        "react-router": "7.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2783,6 +2844,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2849,6 +2915,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,10 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@tailwindcss/vite": "^4.0.9",
     "lucide-react": "^0.477.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+a, Link, button {
+    cursor: pointer;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,28 @@
-import Homepage from './components/CasinoSite'
-import './App.css'
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import Home from "./components/Home";
+import SlotsGame from "./components/games/SlotsGame"; // Example slot page component
+import "./App.css";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import About from "./components/About";
 
 function App() {
   return (
-    <Homepage />
-  )
+    <Router>
+    <div className="h-screen overflow-hidden bg-black text-white flex flex-col">
+      <Header />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/slots" element={<SlotsGame />} />
+          <Route path="/blackjack" element={<h1>Blackjack</h1>} />
+          <Route path="/dice" element={<h1>Dice Games</h1>} />
+          <Route path="/profile" element={<h1>Profile</h1>} />
+          <Route path="/about" element={<About />} />
+        </Routes>
+      <Footer />
+    </div>
+    </Router>
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -1,0 +1,26 @@
+export default function About() {
+  return (
+    <main className="flex-grow flex flex-col overflow-hidden bg-gradient-to-b from-gray-900 to-black py-12 min-h-screen">
+        <div className="container max-w-4xl mx-auto">
+      <div className="bg-gray-800 border border-yellow-400 rounded-lg p-6">
+        <h1 className="text-3xl font-bold mb-4">About FEPSino</h1>
+        <p className="text-lg text-gray-400">
+          FEPSino is a fictional online casino that offers a variety of games
+          for entertainment purposes. This project is a demo to showcase the use
+          of React, Tailwind CSS, and Lucide icons.
+        </p>
+      </div>
+      <div className="bg-gray-800 border border-yellow-400 rounded-lg p-6 mt-8">
+        <h1 className="text-3xl font-bold mb-4">Created by:</h1>
+        <ul className="text-lg text-gray-400">
+          <li>Vic. Kondratska: Team Lead, Frontend Developer</li>
+          <li>Nik. Pashchuk: Backend Developer</li>
+          <li>Vol. Demchyshyn: Backend Developer</li>
+          <li>Mar. Husak: Backend Developer</li>
+          <li>Dmy. Bilyk: Backend Developer</li>
+        </ul>
+      </div>
+    </div>
+    </main>
+  );
+}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer>
+      <div className="footer bg-gradient-to-b from-black to-gray-900 py-12 h-64"></div>
+      <div className="bg-gray-900 py-4">
+        <div className="container mx-auto text-center">
+          <p>&copy; 2025 FEPSino. All rights reserved.</p>
+          <p className="text-sm text-gray-400">Please gamble responsibly. 18+</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { HomeIcon, User, InfoIcon } from 'lucide-react';
+
+export default function Header() {
+  return (
+    <header className="bg-gray-900 p-4">
+      <div className="container mx-auto flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-yellow-400">FEPSino</h1>
+        <nav className="hidden md:block">
+          <ul className="flex space-x-4">
+            <li>
+              <Link to="/" className="flex flex-col items-center space-y-1 hover:text-yellow-400">
+                <HomeIcon className="h-6 w-6" />
+                <span>Home</span>
+              </Link>
+            </li>
+            <li>
+              <Link to="/profile" className="flex flex-col items-center space-y-1 hover:text-yellow-400">
+                <User className="h-6 w-6" />
+                <span>Profile</span>
+              </Link>
+            </li>
+            <li>
+              <Link to="/about" className="flex flex-col items-center space-y-1 hover:text-yellow-400">
+                <InfoIcon className="h-6 w-6" />
+                <span>About</span>
+              </Link>
+            </li>
+          </ul>
+        </nav>
+        <button className="border border-yellow-400 bg-yellow-400 text-black px-4 py-2 rounded hover:bg-yellow-500 transition-colors">
+          Login / Sign Up
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Coins, Dice5, Club } from "lucide-react";
+import { Link } from "react-router-dom";
+
+function GameCard({ title, description, icon, link }) {
+  return (
+    <div className="bg-gray-800 border border-yellow-400 rounded-lg p-6 text-center">
+      <div className="flex items-center justify-center text-2xl font-bold text-yellow-400">
+        {icon}
+        <span className="ml-2">{title}</span>
+      </div>
+      <p className="text-gray-300 mt-4">{description}</p>
+      <Link to={link}>
+        <button className="bg-yellow-400 text-black hover:bg-yellow-500 px-6 py-2 rounded mt-4 transition-colors">
+          Play Now
+        </button>
+      </Link>
+    </div>
+  );
+}
+
+export default function Home() {
+  return (
+    <main className="flex-grow flex flex-col overflow-hidden bg-gradient-to-b bg-gradient-from-b from-gray-900 to-black pt-12 pb-4">
+      <section className="flex-none flex items-center justify-center">
+        <div className="container mx-auto text-center">
+          <h2 className="text-4xl md:text-6xl font-bold my-4">
+            Welcome to FEPSino
+          </h2>
+          <p className="text-xl mb-1">
+            Experience the thrill of our exclusive games.
+          </p>
+        </div>
+      </section>
+
+      <section className="flex-grow flex items-center justify-center mt-16">
+        <div className="container mx-auto">
+          <h2 className="text-3xl font-bold mb-4 text-center">
+            Our Featured Games
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            <GameCard
+              title="Slot Machines"
+              description="Spin to win with our wide variety of themed slot machines."
+              icon={<Coins className="h-12 w-12 text-yellow-400" />}
+              link="/slots"
+            />
+            <GameCard
+              title="Blackjack"
+              description="Test your skills against our dealers in this classic card game."
+              icon={<Club className="h-12 w-12 text-yellow-400" />}
+              link="/blackjack"
+            />
+            <GameCard
+              title="Dice Games"
+              description="Roll the dice and try your luck with our exciting dice games."
+              icon={<Dice5 className="h-12 w-12 text-yellow-400" />}
+              link="/dice"
+            />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/games/SlotsGame.jsx
+++ b/frontend/src/components/games/SlotsGame.jsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import { Coins, RotateCcw, Play, Star, Heart, Cherry, GemIcon, CitrusIcon } from 'lucide-react';
+
+const SYMBOLS = [
+  <Star className="h-12 w-12 text-yellow-400" />,
+  <Heart className="h-12 w-12 text-red-400" />,
+  <Cherry className="h-12 w-12 text-red-400" />,
+  <GemIcon className="h-12 w-12 text-blue-400" />,
+  <CitrusIcon className="h-12 w-12 text-yellow-400" />,
+];
+
+export default function SlotsGame() {
+  const [reels, setReels] = useState([SYMBOLS[0], SYMBOLS[0], SYMBOLS[0]]);
+  const [isSpinning, setIsSpinning] = useState(false);
+  const [balance, setBalance] = useState(1000);
+  const [bet, setBet] = useState(10);
+  const [lastWin, setLastWin] = useState(0);
+
+  const spin = () => {
+    if (balance < bet) return;
+    setIsSpinning(true);
+    setBalance(prev => prev - bet);
+
+    let shuffleCount = 0;
+    const maxShuffles = 20; // How many times the symbols should change before stopping
+
+    const spinInterval = setInterval(() => {
+      setReels([
+        SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)],
+        SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)],
+        SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)],
+      ]);
+
+      shuffleCount++;
+      if (shuffleCount >= maxShuffles) {
+        clearInterval(spinInterval);
+
+        // Set final results
+        const finalReels = [
+          SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)],
+          SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)],
+          SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)],
+        ];
+        setReels(finalReels);
+        setIsSpinning(false);
+
+        // Calculate winnings
+        if (finalReels[0] === finalReels[1] && finalReels[1] === finalReels[2]) {
+          const winAmount = bet * 10;
+          setBalance(prev => prev + winAmount);
+          setLastWin(winAmount);
+        } else if (finalReels[0] === finalReels[1] || finalReels[1] === finalReels[2]) {
+          const winAmount = bet * 2;
+          setBalance(prev => prev + winAmount);
+          setLastWin(winAmount);
+        } else {
+          setLastWin(0);
+        }
+      }
+    }, 100);
+  };
+
+  return (
+    <div className="bg-black text-white">
+      <main className="flex-grow flex flex-col overflow-hidden bg-gradient-to-b from-gray-900 to-black pt-5">
+        <div className="container max-w-4xl mx-auto">
+          <div className="bg-gray-800 border border-yellow-400 rounded-lg p-6 mb-8">
+            <div className="flex justify-between items-center mb-4">
+              <div className="flex items-center">
+                <Coins className="h-6 w-6 text-yellow-400 mr-2" />
+                <span className="text-xl">Balance: ${balance}</span>
+              </div>
+              <div className="flex items-center">
+                <span className="text-xl text-yellow-400">Last Win: ${lastWin}</span>
+              </div>
+            </div>
+
+            <div className="flex gap-4 items-center">
+              <div className="flex-1">
+                <label className="block text-sm mb-1">Bet Amount</label>
+                <select 
+                  value={bet}
+                  onChange={(e) => setBet(Number(e.target.value))}
+                  className="w-full bg-gray-700 rounded p-2 text-white"
+                >
+                  <option value="10">$10</option>
+                  <option value="20">$20</option>
+                  <option value="50">$50</option>
+                  <option value="100">$100</option>
+                </select>
+              </div>
+
+              <button
+                onClick={() => setBet(prev => Math.min(prev * 2, 100))}
+                className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600"
+              >
+                2x
+              </button>
+
+              <button
+                onClick={() => setBet(10)}
+                className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600"
+              >
+                <RotateCcw className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+
+          <div className="bg-gray-800 rounded-lg border border-yellow-400 p-8 mb-8">
+            <div className="flex justify-center mb-8">
+              <div className="grid grid-cols-3 gap-4">
+                {reels.map((symbol, index) => (
+                  <div
+                    key={index}
+                    className="w-24 h-24 bg-gray-700 rounded-lg flex items-center justify-center text-4xl overflow-hidden"
+                  >
+                    {symbol}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={spin}
+              disabled={isSpinning || balance < bet}
+              className={`w-full py-4 rounded-lg flex items-center justify-center text-xl font-bold transition-colors ${
+                isSpinning || balance < bet
+                  ? 'bg-gray-600 cursor-not-allowed'
+                  : 'bg-yellow-400 hover:bg-yellow-500 text-black'
+              }`}
+            >
+              <Play className="h-6 w-6 mr-2" />
+              {isSpinning ? 'Spinning...' : 'Spin'}
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,4 +5,7 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    port: 5173
+  }
 })


### PR DESCRIPTION
# 1. Reformatted frontend structure
For future comfortable development, I have separated my demo page of the home page of the website into 3 parts: [`Header.jsx`](https://github.com/gearbeagel/FEPsino/blob/slots-frontend/frontend/src/components/Header.jsx), [`Home.jsx`](https://github.com/gearbeagel/FEPsino/blob/slots-frontend/frontend/src/components/Home.jsx) and [`Footer.jsx`](https://github.com/gearbeagel/FEPsino/blob/slots-frontend/frontend/src/components/Footer.jsx). 

# 2. Created the slots functionality
Since it is developed as a preset, it serves as an approximate outlook of the page. 