### PR TITLE
[add] sonarscanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ from the project root directory.
 
 To run the project next times use:
 ```bash
-docker-compose up
+docker-compose up 
 ```
 
 backend works on port 8000 and frontend on port 5173.
 
+## Sonarqube
+
+This project uses Sonarqube for easy revirw and refactoring of the code. Sonarqube and Sonar Scanner are ran with the whole project automatically. 
+
+To manually launch the Sonarqube Scanner, you need to run this command:
+```bash
+docker-compose up sonarscanner
+```
 
 ## Example of .env file (create in the root of the project):
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ backend works on port 8000 and frontend on port 5173.
 
 ## Sonarqube
 
-This project uses Sonarqube for easy revirw and refactoring of the code. Sonarqube and Sonar Scanner are ran with the whole project automatically. 
+This project uses Sonarqube for easy review and refactoring of the code. Sonarqube and Sonar Scanner are ran with the whole project automatically. 
 
 To manually launch the Sonarqube Scanner, you need to run this command:
 ```bash

--- a/backend/scripts/wait-for-sonar.sh
+++ b/backend/scripts/wait-for-sonar.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo "Waiting for SonarQube..."
+while ! curl -s "$SONAR_HOST_URL/api/system/status" | grep -q "UP"; do
+  sleep 1
+  echo "Waiting for SonarQube to start..."
+done
+echo "SonarQube is ready."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,28 @@ services:
     depends_on:
       - db
 
+  sonarscanner:
+    image: sonarsource/sonar-scanner-cli:latest
+    container_name: sonarscanner
+    environment:
+      - SONAR_HOST_URL=${SONAR_HOST_URL}
+      - SONAR_LOGIN=${SONAR_TOKEN}
+    volumes:
+      - ./backend:/usr/src
+    depends_on:
+      - sonarqube
+    command: >
+      sh -c "./scripts/wait-for-sonar.sh sonarqube:9000 -- 
+             sonar-scanner -Dsonar.token=$SONAR_TOKEN -Dsonar.projectKey=$SONAR_PROJECT_KEY -Dsonar.projectName=$SONAR_PROJECT_NAME"
+    restart: "no"
+    networks:
+      - default
+
 volumes:
   postgres_data:
   sonarqube_data:
   sonarqube_logs:
+
+networks:
+  default:
+    driver: bridge


### PR DESCRIPTION
Now the project supports using the Sonarqube scanner to review the code!

**Changes:**

1. Added the sonarscanner image in [`docker-compose.yml`](https://github.com/gearbeagel/FEPsino/blob/sonar-scanner/docker-compose.yml)
2. Added a [script](https://github.com/gearbeagel/FEPsino/blob/sonar-scanner/backend/scripts/wait-for-sonar.sh) for waiting on Sonar to start.